### PR TITLE
メタデータに全角文字を含む場合の処理の追加

### DIFF
--- a/src/model/ApostilleTransaction.ts
+++ b/src/model/ApostilleTransaction.ts
@@ -1,4 +1,5 @@
-import { Account, MultisigAccountModificationTransaction, AccountMetadataTransaction, TransferTransaction, Deadline, PlainMessage, NetworkType, InnerTransaction, PublicAccount, AggregateTransaction } from "symbol-sdk";
+import { Account, MultisigAccountModificationTransaction, AccountMetadataTransaction, TransferTransaction, Deadline, PlainMessage, NetworkType, InnerTransaction, PublicAccount, AggregateTransaction , Convert } from "symbol-sdk";
+
 import { HashingType, HashFunctionCreator, DataView } from "../utils/hash";
 import { MetadataKeyHelper } from "../utils/MetadataKeyHelper";
 import { ApostilleAccount } from "./ApostilleAccount";
@@ -268,9 +269,7 @@ export class ApostilleTransaction {
           Deadline.create(this.epochAdjustment),
           this.apostilleAccount.publicAccount.address,
           MetadataKeyHelper.keyToKeyId(k),
-          [...v]
-            .map((x) => (!x.match(/[^\x01-\x7E]/) ? Number(1) : Number(6)))
-            .reduce((p, c) => p + c),
+          Convert.utf8ToUint8(v).length,
           v,
           this.networkType
         );

--- a/src/model/ApostilleTransaction.ts
+++ b/src/model/ApostilleTransaction.ts
@@ -268,10 +268,12 @@ export class ApostilleTransaction {
           Deadline.create(this.epochAdjustment),
           this.apostilleAccount.publicAccount.address,
           MetadataKeyHelper.keyToKeyId(k),
-          v.length,
+          [...v]
+            .map((x) => (!x.match(/[^\x01-\x7E]/) ? Number(1) : Number(6)))
+            .reduce((p, c) => p + c),
           v,
-          this.networkType,
-        )
+          this.networkType
+        );
         txs.push(tx);
       });
       this.metaDataTransactions = txs;

--- a/test/model/ApostilleTransaction.spec.ts
+++ b/test/model/ApostilleTransaction.spec.ts
@@ -150,6 +150,38 @@ describe('Should create apostille transaction', () => {
       expect(x.value).toEqual(authorName);
     });
   });
+  it('Should create apostille transaction with metadata fullwidth characters', () => {
+    const authorName = '三郎 山田';
+    const metadata: IApostilleMetadata = {
+      author: authorName,
+    };
+    const options: IApostilleOptions = {
+      metadata,
+    };
+    const transaction = ApostilleTransaction.createFromHashedData(
+      hashedData,
+      HashingType.Type.sha256,
+      seed,
+      signerAccount,
+      networkType,
+      generationHashSeed,
+      feeMultiplier,
+      apiEndpoint,
+      epochAdjustment,
+      options
+    );
+
+    expect(transaction.coreTransaction).toBeDefined();
+    expect(transaction.assignOwnerShipTransaction).toBeUndefined();
+    expect(transaction.metaDataTransactions).toBeDefined();
+    expect(transaction.metaDataTransactions!.length).toEqual(Object.keys(metadata).length);
+    transaction.metaDataTransactions!.forEach((x) => {
+      const targetAddress= x.targetAddress as Address;
+      expect(targetAddress.plain()).toEqual(transaction.apostilleAccount.publicAccount.address.plain());
+      expect(x.scopedMetadataKey).toEqual(MetadataKeyHelper.keyToKeyId('author'));
+      expect(x.value).toEqual(authorName);
+    });
+  });
 });
 
 describe('Should create update transaction', () => {


### PR DESCRIPTION
メタデータに全角文字を含む場合、メタデータのバイトサイズが異なり`Failure_Metadata_Value_Size_Delta_Mismatch` エラーが発生する点の修正