### PR TITLE
メタデータの全角文字への対応

### DIFF
--- a/src/model/ApostilleTransaction.ts
+++ b/src/model/ApostilleTransaction.ts
@@ -269,8 +269,8 @@ export class ApostilleTransaction {
           Deadline.create(this.epochAdjustment),
           this.apostilleAccount.publicAccount.address,
           MetadataKeyHelper.keyToKeyId(k),
-          Convert.utf8ToUint8(v).length,
-          v,
+          Convert.utf8ToHex(v).length,
+          Convert.utf8ToHex(v),
           this.networkType
         );
         txs.push(tx);

--- a/test/model/ApostilleTransaction.spec.ts
+++ b/test/model/ApostilleTransaction.spec.ts
@@ -1,4 +1,4 @@
-import { Account, NetworkType, Address } from "symbol-sdk";
+import { Account, NetworkType, Address, Convert } from "symbol-sdk";
 import { ApostilleTransaction, IApostilleOptions, IApostilleMetadata } from "../../src/model";
 import { HashingType } from "../../src/utils/hash";
 import { MetadataKeyHelper } from "../../src/utils";
@@ -147,7 +147,7 @@ describe('Should create apostille transaction', () => {
       const targetAddress= x.targetAddress as Address;
       expect(targetAddress.plain()).toEqual(transaction.apostilleAccount.publicAccount.address.plain());
       expect(x.scopedMetadataKey).toEqual(MetadataKeyHelper.keyToKeyId('author'));
-      expect(x.value).toEqual(authorName);
+      expect(Convert.decodeHex(x.value)).toEqual(authorName);
     });
   });
   it('Should create apostille transaction with metadata fullwidth characters', () => {
@@ -179,7 +179,7 @@ describe('Should create apostille transaction', () => {
       const targetAddress= x.targetAddress as Address;
       expect(targetAddress.plain()).toEqual(transaction.apostilleAccount.publicAccount.address.plain());
       expect(x.scopedMetadataKey).toEqual(MetadataKeyHelper.keyToKeyId('author'));
-      expect(x.value).toEqual(authorName);
+      expect(Convert.decodeHex(x.value)).toEqual(authorName);
     });
   });
 });


### PR DESCRIPTION
全角文字でメタデータを作成した際に文字化けが発生する点の修正